### PR TITLE
페이지 컴포넌트들 구현 및 라우팅

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,6 @@
   "plugins": ["react", "react-hooks"],
   "rules": {
     "react-hooks/rules-of-hooks": "error",
-    "react-hooks/exhaustive-deps": "warn",
-    "react/prop-types": "off"
+    "react-hooks/exhaustive-deps": "warn"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.7.1",
         "@emotion/styled": "^11.6.0",
+        "prop-types": "^15.8.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "dependencies": {
     "@emotion/react": "^11.7.1",
     "@emotion/styled": "^11.6.0",
+    "prop-types": "^15.8.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.2.1",

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -85,8 +85,10 @@ function Header() {
         </SearchBar>
       </HeaderColumn>
       <HeaderColumn>
-        <icons.PartyIcon />
-        <Link to="/login">
+        <Link to="/my-party">
+          <icons.PartyIcon />
+        </Link>
+        <Link to="/mypage">
           <icons.ProfileIcon />
         </Link>
         <icons.NotificationIcon />

--- a/src/components/Logo.jsx
+++ b/src/components/Logo.jsx
@@ -37,7 +37,7 @@ const Title = styled.div`
 
 function Logo() {
   return (
-    <Link to="/">
+    <Link to="/main">
       <Container>
         <Image src={images.logo} />
         <Title>엔빵</Title>

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -1,5 +1,6 @@
 import styled from '@emotion/styled';
 import React from 'react';
+import PropTypes from 'prop-types';
 import { COLORS, SIZES } from '../styles/constants';
 
 const Container = styled.main`
@@ -19,6 +20,10 @@ const InnerContainer = styled.div`
 
   height: 3000px;
 `;
+
+Main.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+};
 
 function Main(props) {
   return (

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -8,6 +8,7 @@ import IndexPage from './pages/IndexPage';
 import MyPage from './pages/MyPage';
 import PartyPage from './pages/PartyPage';
 import ChattingPage from './pages/ChattingPage';
+import MyPartyPage from './pages/MyPartyPage';
 
 ReactDOM.render(
   <React.StrictMode>
@@ -19,7 +20,7 @@ ReactDOM.render(
         <Route path="/main" element={<MainPage />} />
         <Route path="/mypage" element={<MyPage />} />
         <Route path="/party" element={<PartyPage />} />
-        <Route path="/my-party" element={<PartyPage />} />
+        <Route path="/my-party" element={<MyPartyPage />} />
         <Route path="/chatting" element={<ChattingPage />} />
       </Routes>
     </BrowserRouter>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,14 +4,22 @@ import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import MainPage from './pages/MainPage';
 import LoginPage from './pages/LoginPage';
 import Reset from './styles/Reset';
+import IndexPage from './pages/IndexPage';
+import MyPage from './pages/MyPage';
+import PartyPage from './pages/PartyPage';
+import ChattingPage from './pages/ChattingPage';
 
 ReactDOM.render(
   <React.StrictMode>
     <BrowserRouter>
       <Reset />
       <Routes>
-        <Route path="/" element={<MainPage />} />
+        <Route path="/" element={<IndexPage />} />
         <Route path="/login" element={<LoginPage />} />
+        <Route path="/main" element={<MainPage />} />
+        <Route path="/mypage" element={<MyPage />} />
+        <Route path="/party" element={<PartyPage />} />
+        <Route path="/chatting" element={<ChattingPage />} />
       </Routes>
     </BrowserRouter>
   </React.StrictMode>,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -19,6 +19,7 @@ ReactDOM.render(
         <Route path="/main" element={<MainPage />} />
         <Route path="/mypage" element={<MyPage />} />
         <Route path="/party" element={<PartyPage />} />
+        <Route path="/my-party" element={<PartyPage />} />
         <Route path="/chatting" element={<ChattingPage />} />
       </Routes>
     </BrowserRouter>

--- a/src/pages/ChattingPage.jsx
+++ b/src/pages/ChattingPage.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Header from '../components/Header';
+import Main from '../components/Main';
+
+function ChattingPage() {
+  return (
+    <>
+      <Header />
+      <Main></Main>
+    </>
+  );
+}
+
+export default ChattingPage;

--- a/src/pages/IndexPage.jsx
+++ b/src/pages/IndexPage.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Header from '../components/Header';
+import Main from '../components/Main';
+
+function IndexPage() {
+  return (
+    <>
+      <Header />
+      <Main></Main>
+    </>
+  );
+}
+
+export default IndexPage;

--- a/src/pages/MyPage.jsx
+++ b/src/pages/MyPage.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Header from '../components/Header';
+import Main from '../components/Main';
+
+function MyPage() {
+  return (
+    <>
+      <Header />
+      <Main></Main>
+    </>
+  );
+}
+
+export default MyPage;

--- a/src/pages/MyPartyPage.jsx
+++ b/src/pages/MyPartyPage.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Header from '../components/Header';
+import Main from '../components/Main';
+
+function MyPartyPage() {
+  return (
+    <>
+      <Header />
+      <Main></Main>
+    </>
+  );
+}
+
+export default MyPartyPage;

--- a/src/pages/PartyPage.jsx
+++ b/src/pages/PartyPage.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Header from '../components/Header';
+import Main from '../components/Main';
+
+function PartyPage() {
+  return (
+    <>
+      <Header />
+      <Main></Main>
+    </>
+  );
+}
+
+export default PartyPage;


### PR DESCRIPTION
- 나중에 쓰일 페이지 컴포넌트들을 미리 만들어뒀습니다.
- 현재 존재하는 페이지는 시작페이지, 메인페이지, 마이페이지, 내파티페이지, 채팅페이지, 파티페이지, 로그인 페이지 이렇게 7개 입니다.
- pr을 보니 propTypes를 사용하셨길래 저도 사용하는 걸로 바꿨습니다.