### PR TITLE
커스텀훅을 이용하여 로직과 뷰를 분리

### DIFF
--- a/src/hooks/useParties.jsx
+++ b/src/hooks/useParties.jsx
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react';
+import { SWAGGER_URL } from '../config';
+
+function useParties(search) {
+  const [parties, setParties] = useState([]);
+  const [option, setOption] = useState({
+    search: search || '',
+    OPEN: true,
+    WISHLIST: false,
+    place: {
+      SINCHON: true,
+      YEONHUI: true,
+      CHANGCHEON: true,
+    },
+  });
+
+  const makeParams = (option) => {
+    const params = [];
+    const placeKeys = Object.keys(option.place);
+
+    if (option.search) {
+      params.push(`search=${option.search}`);
+    }
+
+    params.push(`status=OPEN`);
+    if (!option.OPEN) {
+      params.push(`status=CLOSED`);
+      params.push(`status=FULL`);
+    }
+
+    if (placeKeys.length === 0) {
+      params.push(`place=NONE`);
+    } else {
+      placeKeys.forEach((place) => {
+        if (option.place[place]) {
+          params.push(`place=${place}`);
+        }
+      });
+    }
+
+    return params;
+  };
+
+  useEffect(() => {
+    const fetchParties = async () => {
+      const params = makeParams(option);
+      const res = await fetch(`${SWAGGER_URL}/parties?${params.join('&')}`);
+      const json = await res.json();
+
+      setParties(json.data.parties);
+    };
+
+    fetchParties();
+  }, [option]);
+
+  return { parties, setOption };
+}
+
+export default useParties;

--- a/src/hooks/useParty.jsx
+++ b/src/hooks/useParty.jsx
@@ -1,0 +1,23 @@
+import { useEffect, useState } from 'react';
+import { SWAGGER_URL } from '../config';
+
+function useParty(id) {
+  const [party, setParty] = useState();
+  const [parties, setParties] = useState([]);
+
+  useEffect(() => {
+    const fetchParty = async () => {
+      const res = await fetch(`${SWAGGER_URL}/parties/${id}`);
+      const json = await res.json();
+
+      setParties(json.data.parties);
+      setParty(json.data);
+    };
+
+    fetchParty();
+  }, [id]);
+
+  return { party, parties };
+}
+
+export default useParty;

--- a/src/pages/IndexPage.jsx
+++ b/src/pages/IndexPage.jsx
@@ -1,58 +1,14 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Header from '../components/Header';
 import Index from '../components/Index';
 import Main from '../components/Main';
 import Parties from '../components/Parties';
 import Footer from '../components/Footer';
 import PartyHeader from '../components/PartyHeader';
-import { SWAGGER_URL } from '../config';
+import useParties from '../hooks/useParties';
 
 function IndexPage() {
-  const [parties, setParties] = useState([]);
-  const [option] = useState({
-    OPEN: true,
-    WISHLIST: false,
-    place: {
-      SINCHON: true,
-      YEONHUI: true,
-      CHANGCHEON: true,
-    },
-  });
-
-  useEffect(() => {
-    const fetchParties = async () => {
-      const params = [];
-
-      if (option.search) {
-        params.push(`search=${option.search}`);
-      }
-
-      params.push(`status=OPEN`);
-      if (!option.OPEN) {
-        params.push(`status=CLOSED`);
-        params.push(`status=FULL`);
-      }
-
-      const placeKeys = Object.keys(option.place);
-
-      if (placeKeys.length === 0) {
-        params.push(`place=NONE`);
-      } else {
-        placeKeys.forEach((place) => {
-          if (option.place[place]) {
-            params.push(`place=${place}`);
-          }
-        });
-      }
-
-      const res = await fetch(`${SWAGGER_URL}/parties?${params.join('&')}`);
-      const json = await res.json();
-
-      setParties(json.data.parties);
-    };
-
-    fetchParties();
-  }, [option]);
+  const { parties } = useParties();
 
   return (
     <>

--- a/src/pages/MainPage.jsx
+++ b/src/pages/MainPage.jsx
@@ -1,60 +1,15 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { useParams } from 'react-router-dom';
 import Footer from '../components/Footer';
 import Header from '../components/Header';
 import Main from '../components/Main';
 import Parties from '../components/Parties';
 import PartyHeader from '../components/PartyHeader';
-import { SWAGGER_URL } from '../config';
+import useParties from '../hooks/useParties';
 
 function MainPage() {
   const { search } = useParams();
-  const [parties, setParties] = useState([]);
-  const [option, setOption] = useState({
-    search,
-    OPEN: true,
-    WISHLIST: false,
-    place: {
-      SINCHON: true,
-      YEONHUI: true,
-      CHANGCHEON: true,
-    },
-  });
-
-  useEffect(() => {
-    const fetchParties = async () => {
-      const params = [];
-
-      if (option.search) {
-        params.push(`search=${option.search}`);
-      }
-
-      params.push(`status=OPEN`);
-      if (!option.OPEN) {
-        params.push(`status=CLOSED`);
-        params.push(`status=FULL`);
-      }
-
-      const placeKeys = Object.keys(option.place);
-
-      if (placeKeys.length === 0) {
-        params.push(`place=NONE`);
-      } else {
-        placeKeys.forEach((place) => {
-          if (option.place[place]) {
-            params.push(`place=${place}`);
-          }
-        });
-      }
-
-      const res = await fetch(`${SWAGGER_URL}/parties?${params.join('&')}`);
-      const json = await res.json();
-
-      setParties(json.data.parties);
-    };
-
-    fetchParties();
-  }, [option]);
+  const { parties, setOption } = useParties(search);
 
   return (
     <>

--- a/src/pages/PartyPage.jsx
+++ b/src/pages/PartyPage.jsx
@@ -1,29 +1,16 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import Header from '../components/Header';
 import Main from '../components/Main';
 import PartyDetail from '../components/PartyDetail';
 import Parties from '../components/Parties';
 import Footer from '../components/Footer';
-import { SWAGGER_URL } from '../config';
 import { useParams } from 'react-router-dom';
 import PartyHeader from '../components/PartyHeader';
+import useParty from '../hooks/useParty';
 
 function PartyPage() {
   const { id } = useParams();
-  const [party, setParty] = useState();
-  const [parties, setParties] = useState([]);
-
-  useEffect(() => {
-    const fetchParty = async () => {
-      const res = await fetch(`${SWAGGER_URL}/parties/${id}`);
-      const json = await res.json();
-
-      setParties(json.data.parties);
-      setParty(json.data);
-    };
-
-    fetchParty();
-  }, [id]);
+  const { party, parties } = useParty(id);
 
   return (
     <>


### PR DESCRIPTION
- 페이지 컴포넌트는 뷰에 가까운데 거기에 fetch 로직이 들어있는게 매우 불편해서 커스텀훅으로 분리했습니다.
- 커스텀훅을 만드는 방법이나 커스텀훅이 작동하는 방식은 단순히 복사-붙여넣기 수준이지만 모델과 뷰를 분리하는데에 효과가 좋습니다.
- 깔끔해진 MainPage, IndexPage, PartyPage를 감상해주시고 리액트 커스텀훅에 대해서 학습하시면 정말정말 도움이 될 것 같습니다!