### PR TITLE
소켓 연동을 통한 실시간 채팅 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^6.2.1",
-        "react-scripts": "^5.0.0"
+        "react-scripts": "^5.0.0",
+        "sockjs-client": "^1.5.2"
       },
       "devDependencies": {
         "eslint-config-prettier": "^8.3.0",
@@ -6975,6 +6976,17 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
+      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
+      "dependencies": {
+        "original": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -10468,6 +10480,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
+    "node_modules/json3": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
+      "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA=="
+    },
     "node_modules/json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -11252,6 +11269,14 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/original": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+      "dependencies": {
+        "url-parse": "^1.4.3"
       }
     },
     "node_modules/p-limit": {
@@ -12818,6 +12843,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -13903,6 +13933,27 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "node_modules/sockjs-client": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.2.tgz",
+      "integrity": "sha512-ZzRxPBISQE7RpzlH4tKJMQbHM9pabHluk0WBaxAQ+wm/UieeBVBou0p4wVnSQGN9QmpAZygQ0cDIypWuqOFmFQ==",
+      "dependencies": {
+        "debug": "^3.2.6",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "^0.11.3",
+        "inherits": "^2.0.4",
+        "json3": "^3.3.3",
+        "url-parse": "^1.5.3"
+      }
+    },
+    "node_modules/sockjs-client/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -14939,6 +14990,15 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "node_modules/util-deprecate": {
@@ -20936,6 +20996,14 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="
     },
+    "eventsource": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-1.1.0.tgz",
+      "integrity": "sha512-VSJjT5oCNrFvCS6igjzPAt5hBzQ2qPBFIbJ03zLI9SE0mxwZpMw6BfJrbFHm1a141AavMEB8JHmBhWAd66PfCg==",
+      "requires": {
+        "original": "^1.0.0"
+      }
+    },
     "execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -23440,6 +23508,11 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE="
     },
+    "json3": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/json3/-/json3-3.3.3.tgz",
+      "integrity": "sha512-c7/8mbUsKigAbLkD5B010BK4D9LZm7A1pNItkEwiUZRpIN66exu/e7YQWysGun+TRKaJp8MhemM+VkfWv42aCA=="
+    },
     "json5": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
@@ -24008,6 +24081,14 @@
         "prelude-ls": "^1.2.1",
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.3"
+      }
+    },
+    "original": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",
+      "integrity": "sha512-hyBVl6iqqUOJ8FqRe+l/gS8H+kKYjrEndd5Pm1MfBtsEKA038HkkdbAl/72EAXGyonD/PFsvmVG+EvcIpliMBg==",
+      "requires": {
+        "url-parse": "^1.4.3"
       }
     },
     "p-limit": {
@@ -25017,6 +25098,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
       "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
     },
+    "querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ=="
+    },
     "queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -25817,6 +25903,29 @@
         "websocket-driver": "^0.7.4"
       }
     },
+    "sockjs-client": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/sockjs-client/-/sockjs-client-1.5.2.tgz",
+      "integrity": "sha512-ZzRxPBISQE7RpzlH4tKJMQbHM9pabHluk0WBaxAQ+wm/UieeBVBou0p4wVnSQGN9QmpAZygQ0cDIypWuqOFmFQ==",
+      "requires": {
+        "debug": "^3.2.6",
+        "eventsource": "^1.0.7",
+        "faye-websocket": "^0.11.3",
+        "inherits": "^2.0.4",
+        "json3": "^3.3.3",
+        "url-parse": "^1.5.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "source-list-map": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
@@ -26573,6 +26682,15 @@
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
       "requires": {
         "punycode": "^2.1.0"
+      }
+    },
+    "url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "requires": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
       }
     },
     "util-deprecate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,8 @@
         "react-dom": "^17.0.2",
         "react-router-dom": "^6.2.1",
         "react-scripts": "^5.0.0",
-        "sockjs-client": "^1.5.2"
+        "sockjs-client": "^1.5.2",
+        "webstomp-client": "^1.2.6"
       },
       "devDependencies": {
         "eslint-config-prettier": "^8.3.0",
@@ -15476,6 +15477,11 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/webstomp-client": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/webstomp-client/-/webstomp-client-1.2.6.tgz",
+      "integrity": "sha512-9HajO6Ki2ViEGIusLZtjM2lcO2VaQUvtXhLQQ4Cm543RLjfTCEgI3sFaiXts3TvfZgrtY/vI/+qUkm2qWD/NVg=="
+    },
     "node_modules/whatwg-encoding": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-1.0.5.tgz",
@@ -27030,6 +27036,11 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg=="
+    },
+    "webstomp-client": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/webstomp-client/-/webstomp-client-1.2.6.tgz",
+      "integrity": "sha512-9HajO6Ki2ViEGIusLZtjM2lcO2VaQUvtXhLQQ4Cm543RLjfTCEgI3sFaiXts3TvfZgrtY/vI/+qUkm2qWD/NVg=="
     },
     "whatwg-encoding": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.2.1",
-    "react-scripts": "^5.0.0"
+    "react-scripts": "^5.0.0",
+    "sockjs-client": "^1.5.2"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.2.1",
     "react-scripts": "^5.0.0",
-    "sockjs-client": "^1.5.2"
+    "sockjs-client": "^1.5.2",
+    "webstomp-client": "^1.2.6"
   },
   "scripts": {
     "start": "react-scripts start",

--- a/src/components/Chat.jsx
+++ b/src/components/Chat.jsx
@@ -64,24 +64,24 @@ const Time = styled.div`
   margin: 0 5px;
 `;
 
-function Chat({ chat, isSender, isContinuous }) {
+function Chat({ chat, isContinuous }) {
   if (isContinuous) {
     return (
-      <Container isSender={isSender} isContinuous={isContinuous}>
-        {!isSender && <Blank />}
+      <Container isSender={chat.isSender} isContinuous={isContinuous}>
+        {!chat.isSender && <Blank />}
         <Content>
-          <InnerContent isSender={isSender}>{chat.content}</InnerContent>
+          <InnerContent isSender={chat.isSender}>{chat.content}</InnerContent>
         </Content>
         <Time>{convertDateToTime(chat.createTime)}</Time>
       </Container>
     );
   }
   return (
-    <Container isSender={isSender}>
-      {!isSender && <Image src={images.logo} />}
+    <Container isSender={chat.isSender}>
+      {!chat.isSender && <Image src={images.logo} />}
       <Content>
-        {!isSender && <Nickname>{chat.sender.nickname}</Nickname>}
-        <InnerContent isSender={isSender}>{chat.content}</InnerContent>
+        {!chat.isSender && <Nickname>{chat.sender.nickname}</Nickname>}
+        <InnerContent isSender={chat.isSender}>{chat.content}</InnerContent>
       </Content>
       <Time>{convertDateToTime(chat.createTime)}</Time>
     </Container>
@@ -90,7 +90,6 @@ function Chat({ chat, isSender, isContinuous }) {
 
 Chat.propTypes = {
   chat: PropTypes.object,
-  isSender: PropTypes.bool,
   isContinuous: PropTypes.bool,
 };
 

--- a/src/components/Chat.jsx
+++ b/src/components/Chat.jsx
@@ -41,7 +41,7 @@ const Content = styled.div`
   flex-direction: column;
   justify-content: center;
 
-  max-width: 50%;
+  max-width: 60%;
   font-size: 14px;
 `;
 
@@ -51,7 +51,7 @@ const InnerContent = styled.div`
   padding: 7px 15px;
   color: ${(props) => props.isSender && COLORS.WHITE};
   border-radius: 20px;
-  white-space: pre;
+  white-space: pre-wrap;
 `;
 
 const Time = styled.div`

--- a/src/components/ChatForm.jsx
+++ b/src/components/ChatForm.jsx
@@ -3,7 +3,7 @@ import styled from '@emotion/styled';
 import PropTypes from 'prop-types';
 import { COLORS, HOVER_CURSOR_PONTER, SCROLL_PRIMARY } from '../styles/constants';
 import { icons } from '../assets/assets';
-import { SWAGGER_URL } from '../config';
+import { SERVER_URL } from '../config';
 
 const Container = styled.div`
   display: flex;
@@ -84,7 +84,7 @@ function ChatForm({ partyId }) {
     const form = new FormData(event.target);
     const chat = form.get('chat');
 
-    fetch(`${SWAGGER_URL}/chats/${partyId}`, {
+    fetch(`${SERVER_URL}/chats/${partyId}`, {
       method: 'POST',
       mode: 'cors',
       headers: { 'Content-Type': 'application/json' },

--- a/src/components/ChatForm.jsx
+++ b/src/components/ChatForm.jsx
@@ -84,6 +84,10 @@ function ChatForm({ partyId }) {
     const form = new FormData(event.target);
     const chat = form.get('chat');
 
+    if (!chat) {
+      return;
+    }
+
     fetch(`${SERVER_URL}/chats/${partyId}`, {
       method: 'POST',
       mode: 'cors',

--- a/src/components/ChatForm.jsx
+++ b/src/components/ChatForm.jsx
@@ -114,7 +114,7 @@ function ChatForm({ partyId }) {
           onChange={onChatChange}
           name="chat"
           ref={chatRef}
-          onKeyUp={onKeyDown}
+          onKeyDown={onKeyDown}
         />
         <FormMenu>
           <FormColumn>

--- a/src/components/Chats.jsx
+++ b/src/components/Chats.jsx
@@ -19,29 +19,46 @@ const Container = styled.div`
   ${SCROLL_PRIMARY};
 `;
 
-function Chats({ chats }) {
+function Chats({ chats, fetchChatRef }) {
   const chatsRef = useRef();
+  const topRef = useRef();
 
   const makeChats = (chats) =>
     chats.map((chat, i, arr) => {
-      const isSender = chat.sender.id === 1;
       const isContinuous = i > 0 && arr[i - 1].sender.id === chat.sender.id;
-      return <Chat key={chat.id} chat={chat} isSender={isSender} isContinuous={isContinuous} />;
+
+      if (i === 0) {
+        return <Chat key={chat.id} chat={chat} isContinuous={isContinuous} isFirst />;
+      } else {
+        return <Chat key={chat.id} chat={chat} isContinuous={isContinuous} />;
+      }
     });
 
   useEffect(() => {
-    if (!chatsRef.current) {
-      return;
-    }
+    const observerCallback = async ([entries]) => {
+      if (entries.isIntersecting) {
+        const newLength = await fetchChatRef.current();
+        const first = chatsRef.current.querySelectorAll(':scope > div');
+        first[newLength].scrollIntoView();
+      }
+    };
 
-    chatsRef.current.scrollTop = window.innerHeight;
-  }, [chats]);
+    const observer = new IntersectionObserver(observerCallback);
+    observer.observe(topRef.current);
+  }, []);
 
-  return <Container ref={chatsRef}>{makeChats(chats)}</Container>;
+  return (
+    <Container ref={chatsRef}>
+      <div ref={topRef} />
+      {makeChats(chats)}
+    </Container>
+  );
 }
 
 Chats.propTypes = {
   chats: PropTypes.arrayOf(PropTypes.object),
+  fetchChatRef: PropTypes.object,
+  isLoading: PropTypes.bool,
 };
 
 export default Chats;

--- a/src/components/Chats.jsx
+++ b/src/components/Chats.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
 import Chat from './Chat';
@@ -19,29 +19,13 @@ const Container = styled.div`
   ${SCROLL_PRIMARY};
 `;
 
-function Chats({ chats, fetchChatRef }) {
-  const chatsRef = useRef();
-  const topRef = useRef();
-
+function Chats({ chats, chatsRef, topRef }) {
   const makeChats = (chats) =>
     chats.map((chat, i, arr) => {
       const isContinuous = i > 0 && arr[i - 1].sender.id === chat.sender.id;
 
       return <Chat key={chat.id} chat={chat} isContinuous={isContinuous} />;
     });
-
-  useEffect(() => {
-    const observerCallback = async ([entries]) => {
-      if (entries.isIntersecting) {
-        const newLength = await fetchChatRef.current();
-        const first = chatsRef.current.querySelectorAll(':scope > div');
-        first[newLength].scrollIntoView();
-      }
-    };
-
-    const observer = new IntersectionObserver(observerCallback);
-    observer.observe(topRef.current);
-  }, []);
 
   return (
     <Container ref={chatsRef}>
@@ -53,8 +37,8 @@ function Chats({ chats, fetchChatRef }) {
 
 Chats.propTypes = {
   chats: PropTypes.arrayOf(PropTypes.object),
-  fetchChatRef: PropTypes.object,
-  isLoading: PropTypes.bool,
+  topRef: PropTypes.object,
+  chatsRef: PropTypes.object,
 };
 
 export default Chats;

--- a/src/components/Chats.jsx
+++ b/src/components/Chats.jsx
@@ -27,11 +27,7 @@ function Chats({ chats, fetchChatRef }) {
     chats.map((chat, i, arr) => {
       const isContinuous = i > 0 && arr[i - 1].sender.id === chat.sender.id;
 
-      if (i === 0) {
-        return <Chat key={chat.id} chat={chat} isContinuous={isContinuous} isFirst />;
-      } else {
-        return <Chat key={chat.id} chat={chat} isContinuous={isContinuous} />;
-      }
+      return <Chat key={chat.id} chat={chat} isContinuous={isContinuous} />;
     });
 
   useEffect(() => {

--- a/src/components/SocketStore.jsx
+++ b/src/components/SocketStore.jsx
@@ -1,0 +1,20 @@
+import React, { createContext } from 'react';
+import PropTypes from 'prop-types';
+import SockJS from 'sockjs-client';
+import Webstomp from 'webstomp-client';
+import { SERVER_URL } from '../config';
+
+export const SocketStoreContext = createContext();
+
+function SocketStore({ children }) {
+  const option = { protocols: Webstomp.VERSIONS.supportedProtocols(), debug: false };
+  const socket = Webstomp.over(new SockJS(`${SERVER_URL}/chat`), option);
+
+  return <SocketStoreContext.Provider value={{ socket }}>{children}</SocketStoreContext.Provider>;
+}
+
+SocketStore.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]),
+};
+
+export default SocketStore;

--- a/src/config.js
+++ b/src/config.js
@@ -1,3 +1,4 @@
-const SWAGGER_URL = 'http://15.165.132.250:8094';
+const SERVER_URL = 'http://15.165.132.250:8094';
+const CHAT_PAGE_SIZE = '20';
 
-export { SWAGGER_URL };
+export { SERVER_URL, CHAT_PAGE_SIZE };

--- a/src/hooks/useChat.jsx
+++ b/src/hooks/useChat.jsx
@@ -1,31 +1,49 @@
-import { useEffect, useState } from 'react';
-import { SWAGGER_URL } from '../config';
+import { useEffect, useRef, useState } from 'react';
+import { CHAT_PAGE_SIZE, SERVER_URL } from '../config';
 
 function useChat(id) {
   const [party, setParty] = useState();
   const [chats, setChats] = useState([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const fetchChatRef = useRef();
 
   useEffect(() => {
-    const fetchParty = async () => {
-      const res = await fetch(`${SWAGGER_URL}/chats/${id}?pageSize=50`);
+    fetchChatRef.current = async () => {
+      if (isLoading) {
+        return;
+      }
+
+      const isInitial = chats.length === 0;
+      const URL = `${SERVER_URL}/chats/${id}${isInitial ? '' : `/messages`}?pageSize=${CHAT_PAGE_SIZE}${
+        isInitial ? '' : `&cursorId=${chats[0].id}`
+      }`;
+
+      setIsLoading(true);
+
+      const res = await fetch(URL);
       const json = await res.json();
 
-      setParty({
-        ownerNickname: json.data.owner.nickname,
-        place: json.data.owner.place,
-        createTime: json.data.createTime,
-        joinNumber: json.data.joinNumber,
-        goalNumber: json.data.goalNumber,
-        status: json.data.status,
-      });
+      setIsLoading(false);
 
-      setChats(json.data.messages);
+      if (isInitial) {
+        setParty({
+          ownerNickname: json.data.owner.nickname,
+          place: json.data.owner.place,
+          createTime: json.data.createTime,
+          joinNumber: json.data.joinNumber,
+          goalNumber: json.data.goalNumber,
+          status: json.data.status,
+          isSender: json.data.isSender,
+        });
+      }
+
+      setChats((prev) => [...json.data.messages, ...prev]);
+
+      return json.data.messages.length;
     };
+  }, [chats]);
 
-    fetchParty();
-  }, [id]);
-
-  return { party, chats };
+  return { party, chats, fetchChatRef };
 }
 
 export default useChat;

--- a/src/hooks/useChat.jsx
+++ b/src/hooks/useChat.jsx
@@ -4,13 +4,13 @@ import { CHAT_PAGE_SIZE, SERVER_URL } from '../config';
 function useChat(id) {
   const [party, setParty] = useState();
   const [chats, setChats] = useState([]);
-  const [isLoading, setIsLoading] = useState(false);
+  const [isReady, setIsReady] = useState(true);
   const fetchChatRef = useRef();
 
   useEffect(() => {
     fetchChatRef.current = async () => {
-      if (isLoading) {
-        return;
+      if (!isReady) {
+        return 0;
       }
 
       const isInitial = chats.length === 0;
@@ -18,12 +18,10 @@ function useChat(id) {
         isInitial ? '' : `&cursorId=${chats[0].id}`
       }`;
 
-      setIsLoading(true);
+      setIsReady(false);
 
       const res = await fetch(URL);
       const json = await res.json();
-
-      setIsLoading(false);
 
       if (isInitial) {
         setParty({
@@ -37,11 +35,14 @@ function useChat(id) {
         });
       }
 
-      setChats((prev) => [...json.data.messages, ...prev]);
+      if (json.data.messages.length > 0) {
+        setIsReady(true);
+        setChats((prev) => [...json.data.messages, ...prev]);
+      }
 
       return json.data.messages.length;
     };
-  }, [chats]);
+  }, [chats, isReady]);
 
   return { party, chats, fetchChatRef };
 }

--- a/src/hooks/useChat.jsx
+++ b/src/hooks/useChat.jsx
@@ -5,10 +5,12 @@ function useChat(id) {
   const [party, setParty] = useState();
   const [chats, setChats] = useState([]);
   const [isReady, setIsReady] = useState(true);
-  const fetchChatRef = useRef();
+
+  const pushOldChatRef = useRef();
+  const pushNewChat = (chat) => setChats((prev) => [...prev, chat]);
 
   useEffect(() => {
-    fetchChatRef.current = async () => {
+    pushOldChatRef.current = async () => {
       if (!isReady) {
         return 0;
       }
@@ -44,7 +46,7 @@ function useChat(id) {
     };
   }, [chats, isReady]);
 
-  return { party, chats, fetchChatRef };
+  return { party, chats, pushOldChatRef, pushNewChat };
 }
 
 export default useChat;

--- a/src/hooks/useChatUpdate.jsx
+++ b/src/hooks/useChatUpdate.jsx
@@ -1,0 +1,37 @@
+import { useEffect, useRef } from 'react';
+
+function useChatUpdate(socket, pushOldChatRef, pushNewChat) {
+  const chatsRef = useRef();
+  const topRef = useRef();
+
+  useEffect(async () => {
+    const onNewChat = ({ body }) => {
+      pushNewChat(JSON.parse(body));
+      chatsRef.current.scroll({ top: chatsRef.current.scrollHeight, behavior: 'smooth' });
+    };
+
+    await new Promise((resolve) => socket.connect({}, resolve));
+    socket.subscribe('/topic/1', onNewChat);
+
+    return () => {
+      socket.unsubscribe('/topic/1', onNewChat);
+    };
+  }, []);
+
+  useEffect(() => {
+    const observerCallback = async ([entries]) => {
+      if (entries.isIntersecting) {
+        const newLength = await pushOldChatRef.current();
+        const first = chatsRef.current.querySelectorAll(':scope > div');
+        first[newLength].scrollIntoView();
+      }
+    };
+
+    const observer = new IntersectionObserver(observerCallback);
+    observer.observe(topRef.current);
+  }, []);
+
+  return { topRef, chatsRef };
+}
+
+export default useChatUpdate;

--- a/src/hooks/useChatUpdate.jsx
+++ b/src/hooks/useChatUpdate.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-function useChatUpdate(socket, pushOldChatRef, pushNewChat) {
+function useChatUpdate(id, socket, pushOldChatRef, pushNewChat) {
   const chatsRef = useRef();
   const topRef = useRef();
 
@@ -13,10 +13,10 @@ function useChatUpdate(socket, pushOldChatRef, pushNewChat) {
     };
 
     await new Promise((resolve) => socket.connect({}, resolve));
-    socket.subscribe('/topic/1', onNewChat);
+    socket.subscribe('/topic/' + id, onNewChat);
 
     return () => {
-      socket.unsubscribe('/topic/1', onNewChat);
+      socket.unsubscribe('/topic/' + id, onNewChat);
     };
   }, []);
 

--- a/src/hooks/useChatUpdate.jsx
+++ b/src/hooks/useChatUpdate.jsx
@@ -7,7 +7,9 @@ function useChatUpdate(socket, pushOldChatRef, pushNewChat) {
   useEffect(async () => {
     const onNewChat = ({ body }) => {
       pushNewChat(JSON.parse(body));
-      chatsRef.current.scroll({ top: chatsRef.current.scrollHeight, behavior: 'smooth' });
+      if (chatsRef.current) {
+        chatsRef.current.scroll({ top: chatsRef.current.scrollHeight, behavior: 'smooth' });
+      }
     };
 
     await new Promise((resolve) => socket.connect({}, resolve));

--- a/src/hooks/useParties.jsx
+++ b/src/hooks/useParties.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { SWAGGER_URL } from '../config';
+import { SERVER_URL } from '../config';
 
 function useParties(search) {
   const [parties, setParties] = useState([]);
@@ -44,7 +44,7 @@ function useParties(search) {
   useEffect(() => {
     const fetchParties = async () => {
       const params = makeParams(option);
-      const res = await fetch(`${SWAGGER_URL}/parties?${params.join('&')}`);
+      const res = await fetch(`${SERVER_URL}/parties?${params.join('&')}`);
       const json = await res.json();
 
       setParties(json.data.parties);

--- a/src/hooks/useParty.jsx
+++ b/src/hooks/useParty.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { SWAGGER_URL } from '../config';
+import { SERVER_URL } from '../config';
 
 function useParty(id) {
   const [party, setParty] = useState();
@@ -7,7 +7,7 @@ function useParty(id) {
 
   useEffect(() => {
     const fetchParty = async () => {
-      const res = await fetch(`${SWAGGER_URL}/parties/${id}`);
+      const res = await fetch(`${SERVER_URL}/parties/${id}`);
       const json = await res.json();
 
       setParties(json.data.parties);

--- a/src/hooks/useSocket.jsx
+++ b/src/hooks/useSocket.jsx
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { SocketStoreContext } from '../components/SocketStore';
+
+function useSocket() {
+  const socket = useContext(SocketStoreContext);
+
+  return { socket };
+}
+
+export default useSocket;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -10,22 +10,25 @@ import PartyPage from './pages/PartyPage';
 import ChatPage from './pages/ChatPage';
 import MyPartyPage from './pages/MyPartyPage';
 import NewPartyPage from './pages/NewPartyPage';
+import SocketStore from './components/SocketStore';
 
 ReactDOM.render(
   <React.StrictMode>
     <BrowserRouter>
       <Reset />
-      <Routes>
-        <Route path="/" element={<IndexPage />} />
-        <Route path="/login" element={<LoginPage />} />
-        <Route path="/main" element={<MainPage />} />
-        <Route path="/main/:search" element={<MainPage />} />
-        <Route path="/mypage" element={<MyPage />} />
-        <Route path="/parties/:id" element={<PartyPage />} />
-        <Route path="/my-party" element={<MyPartyPage />} />
-        <Route path="/chats/:id" element={<ChatPage />} />
-        <Route path="/newparty" element={<NewPartyPage />} />
-      </Routes>
+      <SocketStore>
+        <Routes>
+          <Route path="/" element={<IndexPage />} />
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/main" element={<MainPage />} />
+          <Route path="/main/:search" element={<MainPage />} />
+          <Route path="/mypage" element={<MyPage />} />
+          <Route path="/parties/:id" element={<PartyPage />} />
+          <Route path="/my-party" element={<MyPartyPage />} />
+          <Route path="/chats/:id" element={<ChatPage />} />
+          <Route path="/newparty" element={<NewPartyPage />} />
+        </Routes>
+      </SocketStore>
     </BrowserRouter>
   </React.StrictMode>,
   document.getElementById('root'),

--- a/src/pages/ChatPage.jsx
+++ b/src/pages/ChatPage.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { useParams } from 'react-router-dom';
 import ChatForm from '../components/ChatForm';
 import Chats from '../components/Chats';
@@ -6,17 +6,21 @@ import Header from '../components/Header';
 import Main from '../components/Main';
 import PartyStatus from '../components/PartyStatus';
 import useChat from '../hooks/useChat';
+import { SocketStoreContext } from '../components/SocketStore';
+import useChatUpdate from '../hooks/useChatUpdate';
 
 function ChatPage() {
   const { id } = useParams();
-  const { party, chats, fetchChatRef } = useChat(id);
+  const { socket } = useContext(SocketStoreContext);
+  const { party, chats, pushOldChatRef, pushNewChat } = useChat(id);
+  const { topRef, chatsRef } = useChatUpdate(socket, pushOldChatRef, pushNewChat);
 
   return (
     <>
       <Header />
       <Main background="LIGHT_GRAY" fitHeight>
         <PartyStatus party={party} />
-        <Chats chats={chats} fetchChatRef={fetchChatRef} />
+        <Chats chats={chats} topRef={topRef} chatsRef={chatsRef} />
         <ChatForm partyId={id} />
       </Main>
     </>

--- a/src/pages/ChatPage.jsx
+++ b/src/pages/ChatPage.jsx
@@ -9,14 +9,14 @@ import useChat from '../hooks/useChat';
 
 function ChatPage() {
   const { id } = useParams();
-  const { party, chats } = useChat(id);
+  const { party, chats, fetchChatRef } = useChat(id);
 
   return (
     <>
       <Header />
       <Main background="LIGHT_GRAY" fitHeight>
         <PartyStatus party={party} />
-        <Chats chats={chats} />
+        <Chats chats={chats} fetchChatRef={fetchChatRef} />
         <ChatForm partyId={id} />
       </Main>
     </>

--- a/src/pages/ChatPage.jsx
+++ b/src/pages/ChatPage.jsx
@@ -13,7 +13,7 @@ function ChatPage() {
   const { id } = useParams();
   const { socket } = useContext(SocketStoreContext);
   const { party, chats, pushOldChatRef, pushNewChat } = useChat(id);
-  const { topRef, chatsRef } = useChatUpdate(socket, pushOldChatRef, pushNewChat);
+  const { topRef, chatsRef } = useChatUpdate(id, socket, pushOldChatRef, pushNewChat);
 
   return (
     <>


### PR DESCRIPTION
- sockJS, webstomp 모듈을 설치했습니다.
- 웹 서비스에 연결되는 순간 소켓을 생성하고, 채팅 페이지에 접속하면 적절한 이벤트를 구독합니다.
- 채팅 페이지에서 나가면 그 이벤트를 구독 해제합니다.
- 일련의 모든 로직들은 `useChat, useChatUpdate`의 커스텀 훅에 모두 들어있습니다.