### PR TITLE
채팅방에 처음 입장하면 소켓이 연결되지 않는 버그 수정

### DIFF
--- a/src/components/SocketStore.jsx
+++ b/src/components/SocketStore.jsx
@@ -1,14 +1,14 @@
 import React, { createContext } from 'react';
 import PropTypes from 'prop-types';
 import SockJS from 'sockjs-client';
-import Webstomp from 'webstomp-client';
+import webstomp from 'webstomp-client';
 import { SERVER_URL } from '../config';
 
 export const SocketStoreContext = createContext();
 
 function SocketStore({ children }) {
-  const option = { protocols: Webstomp.VERSIONS.supportedProtocols(), debug: false };
-  const socket = Webstomp.over(new SockJS(`${SERVER_URL}/chat`), option);
+  const option = { protocols: webstomp.VERSIONS.supportedProtocols(), debug: false };
+  const socket = webstomp.over(new SockJS(`${SERVER_URL}/chat`), option);
 
   return <SocketStoreContext.Provider value={{ socket }}>{children}</SocketStoreContext.Provider>;
 }


### PR DESCRIPTION
소켓이 이미 연결된 상태에서 다시 연결을 시도했기 때문에 버그가 발생했습니다. 수정하고, cleanup 로직을 추가했습니다.